### PR TITLE
Adiciona o campo `gateway_transaction_code` na resposta do moip e pagar.me

### DIFF
--- a/lib/active_merchant/billing/gateways/moip/moip_core.rb
+++ b/lib/active_merchant/billing/gateways/moip/moip_core.rb
@@ -223,7 +223,8 @@ module ActiveMerchant #:nodoc:
           Response.new(success?(response), message_from(response), params, test: test?,
             authorization: authorization || authorization_from(response),
             payment_action: status_action_from(response, payment_method),
-            external_url: params[:url])
+            external_url: params[:url],
+            gateway_transaction_code: gateway_transaction_code_from(response))
         end
       end
 
@@ -275,6 +276,7 @@ module ActiveMerchant #:nodoc:
         if response.has_key?('EnviarInstrucaoUnicaResponse')
           response['EnviarInstrucaoUnicaResponse']['Resposta']['Token']
         else
+          
           if @query
             payments = response['ConsultarTokenResponse']['RespostaConsultar']['Autorizacao']['Pagamento']
 
@@ -282,6 +284,20 @@ module ActiveMerchant #:nodoc:
           else
             response['CodigoMoIP']
           end
+        end
+      end
+
+      def gateway_transaction_code_from(response)
+        if !response.has_key?('EnviarInstrucaoUnicaResponse')          
+          if @query
+            payments = response['ConsultarTokenResponse']['RespostaConsultar']['Autorizacao']['Pagamento']
+
+            payments.is_a?(Array) ? payments.last['CodigoMoIP'] : payments['CodigoMoIP']
+          else
+            response['CodigoMoIP']
+          end
+        else
+          nil
         end
       end
 

--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -247,19 +247,21 @@ module ActiveMerchant #:nodoc:
 
       def commit(method, url, parameters, options = {})
         response = api_request(method, url, parameters, options)
+        authorization = authorization_from(response)
 
         Response.new(
           success_from(response),
           message_from(response),
           response,
-          authorization: authorization_from(response),
+          authorization: authorization,
           test: test?,
           error_code: error_code_from(response),
           plan_code: plan_code_from(response),
           external_url: boleto_url_from(response),
           payment_action: payment_action_from(response),
           subscription_action: subscription_action_from(response),
-          card: card_from(response)
+          card: card_from(response),
+          gateway_transaction_code: authorization
         )
       end
 

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result,
                   :error_code, :emv_authorization, :payment_action, :external_url,
                   :subscription_action, :next_charge_at, :plan_code, :boleto_url,
-                  :card, :invoice_id
+                  :card, :invoice_id, :gateway_transaction_code
 
       def success?
         @success
@@ -37,6 +37,7 @@ module ActiveMerchant #:nodoc:
         @boleto_url          = options[:boleto_url]
         @card                = options[:card]
         @invoice_id          = options[:invoice_id]
+        @gateway_transaction_code = options[:gateway_transaction_code]
 
         @avs_result = if options[:avs_result].kind_of?(AVSResult)
           options[:avs_result].to_hash

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.55.0.48"
+  VERSION = "1.55.0.49"
 end

--- a/test/unit/gateways/pagarme_test.rb
+++ b/test/unit/gateways/pagarme_test.rb
@@ -296,7 +296,6 @@ class PagarmeTest < Test::Unit::TestCase
     response = @gateway.recurring(@amount, @credit_card, @options)
 
     assert_instance_of Response, response
-    binding.pry
 
     assert_equal 'credit_card', response.params["payment_method"]
     assert_equal 'paid', response.params["status"]


### PR DESCRIPTION
Foi necessário adicionar um novo campo chamado `gateway_transaction_code` a resposta do moip e do pagarme. Este campo identifica uma transação específica do gateway quando uma notificação de alteração de status de pagamento for recebida. Sua adição foi necessária devido ao `gateway_reference`, que já armazenávamos, não ser informado nessa notificação no caso do moip.

Para isso adicionei o novo campo na class Response:

**lib/active_merchant/billing/response.rb**

```
    class Response
      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result,
                  :error_code, :emv_authorization, :payment_action, :external_url,
                  :subscription_action, :next_charge_at, :plan_code, :boleto_url,
                  :card, :invoice_id, :gateway_transaction_code
      [...]
      def initialize(success, message, params = {}, options = {})

        [...]
        @gateway_transaction_code = options[:gateway_transaction_code]
        [...]
       
      end
    end
```

No caso do moip o valor é preenchido com o `CodigoMoip` que é o campo passado pela notificação NASP:

**active_merchant/billing/gateways/moip/moip_core.rb**

```
      def commit(method, format, url, parameters, headers = {}, payment_method = nil, authorization = nil)

          [...]

          Response.new(success?(response), message_from(response), params, test: test?,
            authorization: authorization || authorization_from(response),
            payment_action: status_action_from(response, payment_method),
            external_url: params[:url],
            gateway_transaction_code: gateway_transaction_code_from(response))

          [...]

      end
```

```
      def gateway_transaction_code_from(response)
        if !response.has_key?('EnviarInstrucaoUnicaResponse')          
          if @query
            payments = response['ConsultarTokenResponse']['RespostaConsultar']['Autorizacao']['Pagamento']

            payments.is_a?(Array) ? payments.last['CodigoMoIP'] : payments['CodigoMoIP']
          else
            response['CodigoMoIP']
          end
        else
          nil
        end
      end
```

No pagar.me o valor corresponde ao authorization:

**lib/active_merchant/billing/gateways/pagarme.rb**

```
      def commit(method, url, parameters, options = {})
        response = api_request(method, url, parameters, options)
        authorization = authorization_from(response)

        Response.new(
          success_from(response),
          message_from(response),
          response,
          authorization: authorization,
          test: test?,
          error_code: error_code_from(response),
          plan_code: plan_code_from(response),
          external_url: boleto_url_from(response),
          payment_action: payment_action_from(response),
          subscription_action: subscription_action_from(response),
          card: card_from(response),
          gateway_transaction_code: authorization
        )
      end
```