### PR TITLE
Adiciona urls para recebimento de notificação de alteração de status de pagamento

### DIFF
--- a/lib/active_merchant/billing/gateways/moip.rb
+++ b/lib/active_merchant/billing/gateways/moip.rb
@@ -59,6 +59,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def authenticate(money, payment_method, options = {})
+        options[:extras][:notification_url] = 'https://services.edools.com/nasp/moip/FiJYKFl3DkCTbhafslFd1YfTC6h0isiNnomQwrIcI'
         commit(:post, 'xml', build_url('authenticate'), build_authenticate_request(money, options), add_authentication, payment_method)
       end
 

--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -19,6 +19,7 @@ module ActiveMerchant #:nodoc:
       self.display_fullname = 'Pagar.me'
       self.display_name = 'Pagar.me'
       self.display_logo = 'https://cdn.edools.com/assets/images/gateways/pagarMe.png'
+      self.postback_url = 'https://services.edools.com/nasp/pagarme/To9v28dQqJ6tpcc65gHr1rIHQAzxbN8RVwUS1nH4'
 
       STANDARD_ERROR_CODE_MAPPING = {
         'refused' => STANDARD_ERROR_CODE[:card_declined],
@@ -60,6 +61,7 @@ module ActiveMerchant #:nodoc:
           add_payment_method(post, payment_method, options)
           add_metadata(post, options)
           add_customer(post, options)
+          add_postback_url(post)
 
           commit(:post, 'transactions', post)
         rescue PagarMe::ResponseError => error
@@ -74,6 +76,7 @@ module ActiveMerchant #:nodoc:
         add_soft_descriptor(post, options)
         add_payment_method(post, payment_method)
         add_metadata(post, options)
+        add_postback_url(post)
 
         post[:capture] = false
 
@@ -189,6 +192,10 @@ module ActiveMerchant #:nodoc:
         post[:metadata][:description] = options[:description]
         post[:metadata][:invoice]     = options[:invoice]
         post[:metadata][:email]       = options[:email]
+      end
+
+      def add_postback_url(post)
+        post[:postback_url] = self.postback_url
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/pagarme/pagarme_recurring_api.rb
+++ b/lib/active_merchant/billing/gateways/pagarme/pagarme_recurring_api.rb
@@ -27,6 +27,8 @@ module ActiveMerchant #:nodoc:
             end
           end
 
+          params[:postback_url] = 'https://services.edools.com/nasp/pagarme/To9v28dQqJ6tpcc65gHr1rIHQAzxbN8RVwUS1nH4'
+
           response            = commit(:post, 'subscriptions', params)
           card                = response.params["card"]
           response_options    = {

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.55.0.50"
+  VERSION = "1.55.0.51"
 end


### PR DESCRIPTION
As urls foram adicionadas para o pagarme e para o moip.

No caso do pagar me é o postback e para o moip é o NASP.