### PR TITLE
Corrige urls nasp

### DIFF
--- a/lib/active_merchant/billing/gateways/moip.rb
+++ b/lib/active_merchant/billing/gateways/moip.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def authenticate(money, payment_method, options = {})
-        options[:extras][:notification_url] = 'https://services.edools.com/nasp/moip/FiJYKFl3DkCTbhafslFd1YfTC6h0isiNnomQwrIcI/#{options[:transaction_id]}'
+        options[:extras][:notification_url] = "https://services.edools.com/nasp/moip/FiJYKFl3DkCTbhafslFd1YfTC6h0isiNnomQwrIcI/#{options[:transaction_id]}"
         commit(:post, 'xml', build_url('authenticate'), build_authenticate_request(money, options), add_authentication, payment_method)
       end
 

--- a/lib/active_merchant/billing/gateways/pagarme/pagarme_recurring_api.rb
+++ b/lib/active_merchant/billing/gateways/pagarme/pagarme_recurring_api.rb
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
             end
           end
 
-          params[:postback_url] = 'https://services.edools.com/nasp/pagarme/To9v28dQqJ6tpcc65gHr1rIHQAzxbN8RVwUS1nH4/#{options[:transaction_id]}'
+          params[:postback_url] = "https://services.edools.com/nasp/pagarme/To9v28dQqJ6tpcc65gHr1rIHQAzxbN8RVwUS1nH4/#{options[:transaction_id]}"
 
           response            = commit(:post, 'subscriptions', params)
           card                = response.params["card"]

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.55.0.51"
+  VERSION = "1.55.0.53"
 end


### PR DESCRIPTION
As urls estavam com aspas simples, por isso não estavam interpretando o transaction_id.